### PR TITLE
[User] User 프로필 추가 (회원 탈퇴, 비밀번호 변경 추가)

### DIFF
--- a/src/main/java/com/bootproj/pmcweb/Config/HttpRequestConfig.java
+++ b/src/main/java/com/bootproj/pmcweb/Config/HttpRequestConfig.java
@@ -1,0 +1,18 @@
+package com.bootproj.pmcweb.Config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.HiddenHttpMethodFilter;
+
+import java.util.Arrays;
+
+@Configuration
+public class HttpRequestConfig {
+    @Bean
+    public FilterRegistrationBean hiddenHttpMethodFilter(){
+        FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean(new HiddenHttpMethodFilter());
+        filterRegistrationBean.setUrlPatterns(Arrays.asList("/*"));
+        return filterRegistrationBean;
+    }
+}

--- a/src/main/java/com/bootproj/pmcweb/Config/SwaggerConfiguraton.java
+++ b/src/main/java/com/bootproj/pmcweb/Config/SwaggerConfiguraton.java
@@ -32,7 +32,7 @@ public class SwaggerConfiguraton {
                 .apiInfo(getApiInfo())
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("com.bootproj.pmcweb.Controller"))
-                .paths(PathSelectors.ant("/user/**"))
+                .paths(PathSelectors.ant("/**"))
                 .build();
 
     }

--- a/src/main/java/com/bootproj/pmcweb/Config/SwaggerConfiguraton.java
+++ b/src/main/java/com/bootproj/pmcweb/Config/SwaggerConfiguraton.java
@@ -1,4 +1,4 @@
-package com.bootproj.pmcweb;
+package com.bootproj.pmcweb.Config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
+++ b/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
@@ -3,6 +3,7 @@ package com.bootproj.pmcweb.Controller;
 import com.bootproj.pmcweb.Domain.Account;
 import com.bootproj.pmcweb.Network.Exception.DuplicateEmailException;
 import com.bootproj.pmcweb.Network.Exception.NoMatchingAcountException;
+import com.bootproj.pmcweb.Network.Exception.PasswordNotMatchException;
 import com.bootproj.pmcweb.Network.Exception.SendEmailException;
 import com.bootproj.pmcweb.Network.Header;
 import com.bootproj.pmcweb.Service.AccountSecurityService;
@@ -103,8 +104,13 @@ public class AccountController {
 
     @PostMapping("/user/changePassword")
     public String changePassword(@AuthenticationPrincipal User user, @RequestParam(value="oldPassword") String oldPassword, @RequestParam(value="newPassword") String newPassword) {
-        // TODO: 이전 비밀번호가 맞는지 검증하기
-        accountSecurityService.changePassword(user.getUsername(), newPassword);
+        try {
+            accountSecurityService.changePassword(user.getUsername(), oldPassword, newPassword);
+        } catch (PasswordNotMatchException e) {
+            log.info(e.getMessage());
+            return "redirect:/user/changePassword";
+        }
+
         return "redirect:/user/profile";
     }
 
@@ -130,7 +136,6 @@ public class AccountController {
     public String signUpConfirm(@RequestParam(value="email") String email, @RequestParam(value="authKey") String authKey) throws NoMatchingAcountException, NoSuchFieldException {
         Account changedUser = accountService.signUpConfirm(authKey, email);
         accountService.signUpConfirm(authKey, email);
-        // TODO: 로그인 페이지로 이동시키기
 //        return new ResponseEntity(Header.OK(changedUser), HttpStatus.OK);
         return "redirect:/user/login";
     }

--- a/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
+++ b/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
@@ -69,8 +69,12 @@ public class AccountController {
 
     // 프로필 화면
     @GetMapping("/user/profile")
-    public String getProfile() {
-        return "user/profile";
+    public ModelAndView getProfile(@AuthenticationPrincipal User user) {
+        Account account = accountService.getUserByEmail(user.getUsername());
+        ModelAndView mv = new ModelAndView("/user/profile");
+        mv.addObject("loginUser", account.getName());
+        mv.addObject("loginUserEmail", account.getEmail());
+        return mv;
     }
 
     /**

--- a/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
+++ b/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
@@ -74,6 +74,7 @@ public class AccountController {
         ModelAndView mv = new ModelAndView("/user/profile");
         mv.addObject("loginUser", account.getName());
         mv.addObject("loginUserEmail", account.getEmail());
+        mv.addObject("loginUserId", account.getId());
         return mv;
     }
 
@@ -83,10 +84,9 @@ public class AccountController {
      */
 
     @DeleteMapping("/user/{id}")
-    @ResponseBody
-    public Header deleteUser(@PathVariable Long id){
+    public String deleteUser(@PathVariable Long id){
         accountService.deleteUser(id);
-        return Header.OK();
+        return "user/login";
     }
 
     @GetMapping("/user/{id}")

--- a/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
+++ b/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
@@ -78,6 +78,12 @@ public class AccountController {
         return mv;
     }
 
+    // 비밀번호 변경 화면
+    @GetMapping("/user/changePassword")
+    public String changePassword() {
+        return "user/changePassword";
+    }
+
     /**
      * REST API
      * made by jiae
@@ -93,6 +99,13 @@ public class AccountController {
     public Header<Account> getUser(@PathVariable Long id) {
         Account account = accountService.getUser(id);
         return Header.OK(account);
+    }
+
+    @PostMapping("/user/changePassword")
+    public String changePassword(@AuthenticationPrincipal User user, @RequestParam(value="oldPassword") String oldPassword, @RequestParam(value="newPassword") String newPassword) {
+        // TODO: 이전 비밀번호가 맞는지 검증하기
+        accountSecurityService.changePassword(user.getUsername(), newPassword);
+        return "redirect:/user/profile";
     }
 
     @PostMapping("/user/sendSignUpEmail")

--- a/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
+++ b/src/main/java/com/bootproj/pmcweb/Controller/AccountController.java
@@ -67,6 +67,12 @@ public class AccountController {
         return "user/login";
     }
 
+    // 프로필 화면
+    @GetMapping("/user/profile")
+    public String getProfile() {
+        return "user/profile";
+    }
+
     /**
      * REST API
      * made by jiae

--- a/src/main/java/com/bootproj/pmcweb/Domain/Account.java
+++ b/src/main/java/com/bootproj/pmcweb/Domain/Account.java
@@ -1,6 +1,7 @@
 package com.bootproj.pmcweb.Domain;
 
 import lombok.*;
+import lombok.experimental.Accessors;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -13,6 +14,8 @@ import java.util.Date;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
+@Builder
+@Accessors(chain=true)
 public class Account {
     private Long id;
 

--- a/src/main/java/com/bootproj/pmcweb/Mapper/AccountMapper.java
+++ b/src/main/java/com/bootproj/pmcweb/Mapper/AccountMapper.java
@@ -21,4 +21,6 @@ public interface AccountMapper {
     public void updateUserAuthKey(Map<String, String> map);
 
     public void updateUserStatus(Map<String, String> map);
+
+    public void updateUserPassword(Map<String, String> map);
 }

--- a/src/main/java/com/bootproj/pmcweb/Network/Exception/PasswordNotMatchException.java
+++ b/src/main/java/com/bootproj/pmcweb/Network/Exception/PasswordNotMatchException.java
@@ -1,0 +1,11 @@
+package com.bootproj.pmcweb.Network.Exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "잘못된 패스워드")
+public class PasswordNotMatchException extends Exception{
+    public PasswordNotMatchException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bootproj/pmcweb/Network/GlobalExceptionHandler.java
+++ b/src/main/java/com/bootproj/pmcweb/Network/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.bootproj.pmcweb.Network;
 
 import com.bootproj.pmcweb.Network.Exception.DuplicateEmailException;
 import com.bootproj.pmcweb.Network.Exception.NoMatchingAcountException;
+import com.bootproj.pmcweb.Network.Exception.PasswordNotMatchException;
 import com.bootproj.pmcweb.Network.Exception.SendEmailException;
 import com.bootproj.pmcweb.Network.Header;
 import com.bootproj.pmcweb.Network.ResultCode;
@@ -84,5 +85,15 @@ public class GlobalExceptionHandler {
         log.error("NoMatchingAcountException");
         log.error(e.getMessage());
         return new ResponseEntity(Header.Error(ResultCode.ERROR_USER_NOT_FOUND), ResultCode.ERROR_USER_NOT_FOUND.getStatus());
+    }
+
+    /**
+     * 유저 패스워드 변경 시 패스워드가 잘못된 경우 발생
+     */
+    @ExceptionHandler(PasswordNotMatchException.class)
+    public ResponseEntity<Header> handlerPasswordNotMatchException(PasswordNotMatchException e){
+        log.error("PasswordNotMatchException");
+        log.error(e.getMessage());
+        return new ResponseEntity(Header.Error(ResultCode.ERROR_INVALID_PASSWORD), ResultCode.ERROR_INVALID_PASSWORD.getStatus());
     }
 }

--- a/src/main/java/com/bootproj/pmcweb/Network/ResultCode.java
+++ b/src/main/java/com/bootproj/pmcweb/Network/ResultCode.java
@@ -19,7 +19,8 @@ public enum ResultCode {
     ERROR_EMAIL_DUPLICATE(HttpStatus.INTERNAL_SERVER_ERROR, "U0001", "이메일이 중복되었습니다."),
     ERROR_USER_NOT_FOUND(HttpStatus.NO_CONTENT, "U0002", "해당하는 유저가 존재하지 않습니다."),
     ERROR_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "U0003", "이메일을 전송하는데 실패했습니다."),
-    ERROR_INSERT_USER(HttpStatus.INTERNAL_SERVER_ERROR, "U0004", "회원정보를 저장하는데 실패했습니다.")
+    ERROR_INSERT_USER(HttpStatus.INTERNAL_SERVER_ERROR, "U0004", "회원정보를 저장하는데 실패했습니다."),
+    ERROR_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U0005", "잘못된 패스워드 입니다.")
 
     ;
 

--- a/src/main/java/com/bootproj/pmcweb/Service/AccountSecurityService.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AccountSecurityService.java
@@ -4,6 +4,7 @@ import com.bootproj.pmcweb.Domain.Account;
 import com.bootproj.pmcweb.Domain.enumclass.UserRole;
 import com.bootproj.pmcweb.Network.Exception.DuplicateEmailException;
 import com.bootproj.pmcweb.Network.Exception.NoMatchingAcountException;
+import com.bootproj.pmcweb.Network.Exception.PasswordNotMatchException;
 import com.bootproj.pmcweb.Network.Exception.SendEmailException;
 import com.bootproj.pmcweb.Network.ResultCode;
 import lombok.SneakyThrows;
@@ -47,11 +48,18 @@ public class AccountSecurityService implements UserDetailsService {
         return accountServiceimpl.sendSignUpEmail(account);
     }
 
-    public void changePassword (String email, String newPassword){
-        HashMap<String, String> map = new HashMap<String, String>();
-        map.put("email", email);
-        map.put("password", passwordEncoder.encode(newPassword));
-        accountServiceimpl.updateUserPassword(map);
+    public void changePassword (String email, String oldPassword, String newPassword) throws PasswordNotMatchException {
+        Account account = accountServiceimpl.getUserByEmail(email);
+        if (passwordEncoder.matches(oldPassword, account.getPassword())){
+            // 비밀번호 변경
+            HashMap<String, String> map = new HashMap<String, String>();
+            map.put("email", email);
+            map.put("password", passwordEncoder.encode(newPassword));
+            accountServiceimpl.updateUserPassword(map);
+        } else {
+            throw new PasswordNotMatchException("패스워드를 잘못 입력하셨습니다.");
+        }
+
         return;
     }
 

--- a/src/main/java/com/bootproj/pmcweb/Service/AccountSecurityService.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AccountSecurityService.java
@@ -47,6 +47,14 @@ public class AccountSecurityService implements UserDetailsService {
         return accountServiceimpl.sendSignUpEmail(account);
     }
 
+    public void changePassword (String email, String newPassword){
+        HashMap<String, String> map = new HashMap<String, String>();
+        map.put("email", email);
+        map.put("password", passwordEncoder.encode(newPassword));
+        accountServiceimpl.updateUserPassword(map);
+        return;
+    }
+
     // 회원가입 시, 유효성 체크
     public Map<String, String> validateHandling(Errors errors) {
         Map<String, String> validatorResult = new HashMap<>();

--- a/src/main/java/com/bootproj/pmcweb/Service/AccountService.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AccountService.java
@@ -18,4 +18,5 @@ public interface AccountService {
     public void updateUserStatus(Map<String, String> map);
     public String sendSignUpEmail(Account account) throws SendEmailException, DuplicateEmailException;
     public Account signUpConfirm(String authKey, String email) throws NoMatchingAcountException, NoSuchFieldException;
+    public void updateUserPassword(Map<String, String> map);
 }

--- a/src/main/java/com/bootproj/pmcweb/Service/AccountServiceImpl.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AccountServiceImpl.java
@@ -119,4 +119,10 @@ public class AccountServiceImpl implements AccountService {
         Account changedUser = getUserByEmail(email);
         return changedUser;
     }
+
+    @Override
+    public void updateUserPassword(Map<String, String> map) {
+        accountMapper.updateUserPassword(map);
+        return;
+    }
 }

--- a/src/main/resources/mappers/AccountMapper.xml
+++ b/src/main/resources/mappers/AccountMapper.xml
@@ -39,4 +39,9 @@
         update User set status = #{status}
         where email = #{email};
     </update>
+
+    <update id="updateUserPassword" parameterType="map">
+        update User set password = #{password}
+        where email = #{email};
+    </update>
 </mapper>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="/layout/common.html :: fragment-common"></head>
+<body>
+    <!-- Navbar -->
+    <nav th:replace="/layout/navbar.html :: fragment-navbar"></nav>
+    <!-- main -->
+    <div class="container">
+        <div class="container-fluid">
+            <div class="row justify-content-center">
+                <!-- 404 Error Text -->
+                <div class="text-center">
+                    <img class="error-img mb-4" th:src="@{/img/moim.jpg}" alt="Error Image" width="200" height="200">
+                    <h2 th:text="${status}"><b></b></h2>
+                    <h4>페이지를 찾을 수 없습니다.</h4></br></br>
+                    <h7 th:text="${error + ' : ' + path}"></h7></br>
+                    <h7 th:text="${timestamp}"></h7></br>
+                    <h6>This requested URL was not found on this server.</h6>
+                    <a href="/"><b>&larr; 메인 화면으로 돌아가기</b></a></br>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/layout/navbar.html
+++ b/src/main/resources/templates/layout/navbar.html
@@ -39,7 +39,7 @@
                             <i class="fas fa-user-circle"></i>
                         </a>
                         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-                            <a sec:authorize="isAuthenticated()" class="dropdown-item" href="#">내 프로필</a>
+                            <a sec:authorize="isAuthenticated()" class="dropdown-item" th:href="@{/user/profile}">내 프로필</a>
                             <a sec:authorize="isAuthenticated()" class="dropdown-item" href="#">즐겨 찾기</a>
                             <a sec:authorize="isAuthenticated()" class="dropdown-item" href="#">내 모임</a>
                         </div>

--- a/src/main/resources/templates/user/changePassword.html
+++ b/src/main/resources/templates/user/changePassword.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+        <html xmlns:th="http://www.thymeleaf.org"
+              xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+        <head>
+            <head th:replace="/layout/common.html :: fragment-common"></head>
+        </head>
+<body class="text-center">
+    <div class="row justify-content-center">
+        <div class="col-md-auto">
+            <form class="form-signin" th:action="@{/user/changePassword}" method="post">
+                <a href="/"><img class="mb-4" th:src="@{/img/moim.jpg}" alt="" width="72" height="72"></a>
+                <h1 class="h3 mb-3 font-weight-normal">비밀번호 변경</h1>
+                <label for="inputOldPassword" class="sr-only">현재 비밀번호</label>
+                <input type="password" name="oldPassword" id="inputOldPassword" class="form-control" placeholder="현재 비밀번호" required autofocus>
+                <label for="inputNewPassword" class="sr-only">변경할 비밀번호</label>
+                <input type="password" name="newPassword" id="inputNewPassword" class="form-control" placeholder="변경할 비밀번호" required>
+                <label for="inputNewPasswordConfirm" class="sr-only">변경할 비밀번호 확인</label>
+                <input type="password" name="newPasswordConfirm" id="inputNewPasswordConfirm" class="form-control" placeholder="변경할 비밀번호 확인" required>
+                <button class="btn btn-lg btn-primary btn-block" type="submit">변경</button>
+                <p class="mt-5 mb-3 text-muted">&copy; 2020-2021</p>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -40,8 +40,8 @@
                                      th:src="@{/img/moim.jpg}"
                                      alt="User profile picture">
                             </div>
-                            <h3 class="profile-username text-center" th:text="${loginUser} +' 님'"></h3>
-                            <p class="text-muted text-center">이메일</p>
+                            <h3 class="profile-username text-center" th:text="${loginUser}"></h3>
+                            <p class="text-muted text-center" th:text="${loginUserEmail}"></p>
                             <ul class="list-group list-group-unbordered mb-3">
                                 <li class="list-group-item">
                                     <b>가입한 모임 수</b> <a class="float-right">3</a>

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<head>
+    <head th:replace="/layout/common.html :: fragment-common"></head>
+</head>
+<body>
+<!-- navbar -->
+<nav th:replace="/layout/navbar.html :: fragment-navbar"></nav>
+<!-- main -->
+<!-- Content Wrapper. Contains page content -->
+<div class="content-wrapper">
+    <!-- Content Header (Page header) -->
+    <section class="content-header">
+        <div class="container-fluid">
+            <div class="row mb-2">
+                <div class="col-sm-6">
+                    <h1>Profile</h1>
+                </div>
+                <div class="col-sm-6">
+                    <ol class="breadcrumb float-sm-right">
+                        <li class="breadcrumb-item"><a href="#">Home</a></li>
+                        <li class="breadcrumb-item active">User Profile</li>
+                    </ol>
+                </div>
+            </div>
+        </div><!-- /.container-fluid -->
+    </section>
+
+    <!-- Main content -->
+    <section class="content">
+        <div class="container-fluid">
+            <div class="row justify-content-center">
+                <div class="col-md-auto">
+                    <!-- Profile Image -->
+                    <div class="card card-primary card-outline">
+                        <div class="card-body box-profile">
+                            <div class="text-center">
+                                <img class="profile-user-img img-fluid img-circle"
+                                     th:src="@{/img/moim.jpg}"
+                                     alt="User profile picture">
+                            </div>
+                            <h3 class="profile-username text-center" th:text="${loginUser} +' 님'"></h3>
+                            <p class="text-muted text-center">이메일</p>
+                            <ul class="list-group list-group-unbordered mb-3">
+                                <li class="list-group-item">
+                                    <b>가입한 모임 수</b> <a class="float-right">3</a>
+                                </li>
+                                <li class="list-group-item">
+                                    <b>운영 모임 수</b> <a class="float-right">1</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <!-- /.card-body -->
+                    </div>
+                    <!-- /.card -->
+
+                    <!-- About Me Box -->
+                    <div class="card card-primary">
+                        <div class="card-header">
+                            <h3 class="card-title">About Me</h3>
+                        </div>
+                        <!-- /.card-header -->
+                        <div class="card-body">
+                            <strong><i class="fas fa-map-marker-alt mr-1"></i> 지역</strong>
+                            <p class="text-muted">강남구</p>
+                            <hr>
+                            <strong><i class="fas fa-pencil-alt mr-1"></i> 관심사</strong>
+
+                            <p class="text-muted">
+                                <span class="tag tag-danger">백엔드 개발</span>
+                                <span class="tag tag-success">알고리즘</span>
+                            </p>
+                            <hr>
+                        </div>
+                        <!-- /.card-body -->
+
+                        <a href="#" class="btn btn-primary btn-block"><b>비밀번호 변경하기</b></a>
+                        <a href="#" class="btn btn-primary btn-block"><b>탈퇴하기</b></a>
+                    </div>
+                    <!-- /.card -->
+                </div>
+                <!-- /.col -->
+            </div>
+            <!-- /.row -->
+        </div><!-- /.container-fluid -->
+    </section>
+    <!-- /.content -->
+</div>
+<!-- /.content-wrapper -->
+</body>
+</html>

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -75,7 +75,7 @@
                         </div>
                         <!-- /.card-body -->
 
-                        <a href="#" class="btn btn-primary btn-block"><b>비밀번호 변경하기</b></a>
+                        <a href="#" class="btn btn-primary btn-block" th:href="@{/user/changePassword}"><b>비밀번호 변경하기</b></a>
 <!--                        <button id ="btn-user-delete" class="btn btn-primary btn-block"><b>탈퇴하기</b></button>-->
 <!--                        <a id ="btn-user-delete" href="#" class="btn btn-primary btn-block" th:href="@{/user/{loginUserId}(loginUserId=${loginUserId})}" data-confirm="탈퇴하시겠습니까?" data-method="delete" rel="nofollow"><b>탈퇴하기</b></a>-->
                         <button id ="btn-user-delete" class="btn btn-primary btn-block" th:onclick="deleteUser([[${loginUserId}]])"><b>탈퇴하기</b></button>

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -76,8 +76,10 @@
                         <!-- /.card-body -->
 
                         <a href="#" class="btn btn-primary btn-block"><b>비밀번호 변경하기</b></a>
-                        <a href="#" class="btn btn-primary btn-block"><b>탈퇴하기</b></a>
-                    </div>
+<!--                        <button id ="btn-user-delete" class="btn btn-primary btn-block"><b>탈퇴하기</b></button>-->
+<!--                        <a id ="btn-user-delete" href="#" class="btn btn-primary btn-block" th:href="@{/user/{loginUserId}(loginUserId=${loginUserId})}" data-confirm="탈퇴하시겠습니까?" data-method="delete" rel="nofollow"><b>탈퇴하기</b></a>-->
+                        <button id ="btn-user-delete" class="btn btn-primary btn-block" th:onclick="deleteUser([[${loginUserId}]])"><b>탈퇴하기</b></button>
+                        </div>
                     <!-- /.card -->
                 </div>
                 <!-- /.col -->
@@ -88,5 +90,24 @@
     <!-- /.content -->
 </div>
 <!-- /.content-wrapper -->
+<th:block layout:fragment="script">
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        function deleteUser(id){
+            if (confirm("정말로 탈퇴하시겠습니까?")){
+                var url = "/user/"+id;
+                var html = "";
+                html += '<form name="dataForm" action="'+url+'" method="post">';
+				html += '<input type="hidden" name="_method" value="delete" />';
+				html += '</form>';
+				console.log("html");
+				$("body").append(html);
+				document.dataForm.submit();
+            }
+        }
+        /*]]>*/
+    </script>
+</th:block>
 </body>
+
 </html>

--- a/src/test/java/com/bootproj/pmcweb/Mapper/UserMapperTest.java
+++ b/src/test/java/com/bootproj/pmcweb/Mapper/UserMapperTest.java
@@ -1,6 +1,8 @@
 package com.bootproj.pmcweb.Mapper;
 
 import com.bootproj.pmcweb.Domain.Account;
+import com.bootproj.pmcweb.Domain.enumclass.UserRole;
+import com.bootproj.pmcweb.Domain.enumclass.UserStatus;
 import com.bootproj.pmcweb.PmcwebApplication;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,6 +11,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.assertj.core.api.Assertions.*;
+
+import java.util.Date;
 import java.util.List;
 
 @ExtendWith(SpringExtension.class) //Junit4의 Runwith과 같은 기능을 하는 Junit5 어노테이션
@@ -19,22 +23,30 @@ public class UserMapperTest {
     @Autowired
     private AccountMapper userMapper;
     private static final String testEmail = "test@naver.com";
+    private static final String testName = "test";
 
     @Test
     @Order(1)
     void createUser() {
-        Account testUser = new Account(testEmail, "password", "name");
-        userMapper.createUser(testUser);
-        Account createdUser = userMapper.getUserById(testUser.getId());
-        assertThat(createdUser.getEmail().equals(testUser.getEmail()));
+        Account account = Account.builder()
+                .name(testName)
+                .email(testEmail)
+                .password("1234")
+                .status(UserStatus.REGISTERED.getTitle())
+                .role(UserRole.NORMAL.getTitle())
+                .instTime(new Date(System.currentTimeMillis()))
+                .build();
+
+        userMapper.createUser(account);
+        Account createdUser = userMapper.getUserByEmail(testEmail);
+        assertThat(createdUser.getEmail().equals(account.getEmail()));
     }
 
     @Test
     @Order(2)
-    void getUserById() {
-        Account testUser = new Account(testEmail, "password", "name");
-        Account getUser = userMapper.getUserByEmail(testUser.getEmail());
-        assertThat(testUser.getName().equals(getUser.getName()));
+    void getUserByEmail() {
+        Account getUser = userMapper.getUserByEmail(testEmail);
+        assertThat(testName.equals(getUser.getName()));
     }
 
     @Test
@@ -48,7 +60,7 @@ public class UserMapperTest {
     @Order(4)
     void deleteUser() {
         Account getUser = userMapper.getUserByEmail(testEmail);
-        assertThat(userMapper.getUserById(getUser.getId())!=null);
+        assertThat(getUser!=null);
         userMapper.deleteUser(getUser.getId());
         assertThat(userMapper.getUserById(getUser.getId())==null);
     }

--- a/src/test/java/com/bootproj/pmcweb/Service/UserServiceTest.java
+++ b/src/test/java/com/bootproj/pmcweb/Service/UserServiceTest.java
@@ -2,6 +2,8 @@ package com.bootproj.pmcweb.Service;
 
 
 import com.bootproj.pmcweb.Domain.Account;
+import com.bootproj.pmcweb.Domain.enumclass.UserRole;
+import com.bootproj.pmcweb.Domain.enumclass.UserStatus;
 import com.bootproj.pmcweb.PmcwebApplication;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -21,23 +24,30 @@ public class UserServiceTest {
     @Autowired
     private AccountServiceImpl userServiceImpl;
     private static final String testEmail = "test@naver.com";
+    private static final String testName = "test";
 
     @Test
     @Order(1)
     void createUser() {
-        Account user = new Account(testEmail, "password", "name");
-        userServiceImpl.createUser(user);
-        Account findUser = userServiceImpl.getUserByEmail(user.getEmail());
-        assertThat(user.getEmail()).isEqualTo(findUser.getEmail());
+        Account account = Account.builder()
+                .name(testName)
+                .email(testEmail)
+                .password("1234")
+                .status(UserStatus.REGISTERED.getTitle())
+                .role(UserRole.NORMAL.getTitle())
+                .instTime(new Date(System.currentTimeMillis()))
+                .build();
+        userServiceImpl.createUser(account);
+        Account findUser = userServiceImpl.getUserByEmail(account.getEmail());
+        assertThat(account.getEmail()).isEqualTo(findUser.getEmail());
     }
 
     @Test
     @Order(2)
     void getUser() {
-        Account user = new Account(testEmail, "password", "name");
         Account getUser = userServiceImpl.getUserByEmail(testEmail);
         assertThat(testEmail.equals(getUser.getEmail()));
-        assertThat(user.getName().equals(getUser.getName()));
+        assertThat(testName.equals(getUser.getName()));
     }
 
     @Test

--- a/src/test/java/com/bootproj/pmcweb/web/UserControllerTest.java
+++ b/src/test/java/com/bootproj/pmcweb/web/UserControllerTest.java
@@ -1,0 +1,12 @@
+package com.bootproj.pmcweb.web;
+
+
+import com.bootproj.pmcweb.Controller.AccountController;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(AccountController.class)
+public class UserControllerTest {
+}


### PR DESCRIPTION
1. 프로필 화면 추가, 비밀번호 변경 화면 추가
    - profile.html, changePassword.html
2. 프로필 화면에 데이터 연동
    -  user email, name 값 연동
3. 비밀번호 변경 기능 추가 및 연동
    - 기존 비밀번호와 다를 경우 다시 비밀번호 변경 창을 띄우고, 변경이 완료되면 프로필 화면으로 이동
    - form 에서 post, get 외에 put과 delete도 사용할 수 있도록 HiddenHttpMethodFilter설정 추가 (회원 탈퇴 버튼 클릭 시 form 을 동적으로 추가해서 deleteUser 호출)
4. 회원 탈퇴 기능 연동
5. user mapper, service 테스트 코드 수정
    - 생성자가 변경되어 수정, 혹시 또 바뀌면 수정하기 귀찮으니까 builder, 체인 어노테이션 추가해서 빌더로 생성함.
6. 404 에러페이지 추가