### PR TITLE
[Alarm] 유저 스터디 일정 알람 기능 추가

### DIFF
--- a/src/main/java/com/bootproj/pmcweb/Common/CommonUtils.java
+++ b/src/main/java/com/bootproj/pmcweb/Common/CommonUtils.java
@@ -1,0 +1,6 @@
+package com.bootproj.pmcweb.Common;
+
+public class CommonUtils {
+    public final static String ALARM_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+}

--- a/src/main/java/com/bootproj/pmcweb/Common/Response/AlarmApiResponse.java
+++ b/src/main/java/com/bootproj/pmcweb/Common/Response/AlarmApiResponse.java
@@ -1,4 +1,4 @@
-package com.bootproj.pmcweb.Domain;
+package com.bootproj.pmcweb.Common.Response;
 
 import com.bootproj.pmcweb.Common.CommonUtils;
 import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
@@ -14,7 +14,7 @@ import java.util.Date;
 @NoArgsConstructor
 @Builder
 @ToString
-public class Alarm {
+public class AlarmApiResponse {
     private Long id;
     private AlarmType type;
     @DateTimeFormat(pattern = CommonUtils.ALARM_DATE_FORMAT)
@@ -22,4 +22,5 @@ public class Alarm {
     private AlarmStatus status;
     private Long userId;
     private Long dateId;
+    private String description; // data table join
 }

--- a/src/main/java/com/bootproj/pmcweb/Controller/AlarmController.java
+++ b/src/main/java/com/bootproj/pmcweb/Controller/AlarmController.java
@@ -1,0 +1,34 @@
+package com.bootproj.pmcweb.Controller;
+
+import com.bootproj.pmcweb.Common.Header;
+import com.bootproj.pmcweb.Domain.Alarm;
+import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
+import com.bootproj.pmcweb.Service.AlarmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/alarm")
+public class AlarmController {
+
+    final AlarmService alarmService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity getAlarmList(@PathVariable(value = "userId") Long userId){
+        List<Alarm> alarms = alarmService.getNotReadListByUserId(userId);
+        return new ResponseEntity(Header.OK(alarms), HttpStatus.OK);
+    }
+
+    @PutMapping("/read/{id}")
+    public ResponseEntity updateAlarmReadStatus(@PathVariable(value="id") Long id){
+        alarmService.updateStatusById(id, AlarmStatus.READ);
+        return new ResponseEntity(Header.OK(), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/bootproj/pmcweb/Controller/AlarmController.java
+++ b/src/main/java/com/bootproj/pmcweb/Controller/AlarmController.java
@@ -22,7 +22,7 @@ public class AlarmController {
 
     @GetMapping("/{userId}")
     public ResponseEntity getAlarmList(@PathVariable(value = "userId") Long userId){
-        List<Alarm> alarms = alarmService.getNotReadListByUserId(userId);
+        List<Alarm> alarms = alarmService.getListByUserId(userId);
         return new ResponseEntity(Header.OK(alarms), HttpStatus.OK);
     }
 

--- a/src/main/java/com/bootproj/pmcweb/Controller/AlarmController.java
+++ b/src/main/java/com/bootproj/pmcweb/Controller/AlarmController.java
@@ -1,12 +1,18 @@
 package com.bootproj.pmcweb.Controller;
 
 import com.bootproj.pmcweb.Common.Header;
+import com.bootproj.pmcweb.Common.Response.AlarmApiResponse;
+import com.bootproj.pmcweb.Domain.Account;
 import com.bootproj.pmcweb.Domain.Alarm;
 import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
+import com.bootproj.pmcweb.Service.AccountService;
 import com.bootproj.pmcweb.Service.AlarmService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,9 +26,12 @@ public class AlarmController {
 
     final AlarmService alarmService;
 
-    @GetMapping("/{userId}")
-    public ResponseEntity getAlarmList(@PathVariable(value = "userId") Long userId){
-        List<Alarm> alarms = alarmService.getListByUserId(userId);
+    final AccountService accountService;
+
+    @GetMapping("")
+    public ResponseEntity getAlarmList(@AuthenticationPrincipal User user){
+        Account account = accountService.getUserByEmail(user.getUsername());
+        List<AlarmApiResponse> alarms = alarmService.getListByUserId(account.getId());
         return new ResponseEntity(Header.OK(alarms), HttpStatus.OK);
     }
 
@@ -31,4 +40,5 @@ public class AlarmController {
         alarmService.updateStatusById(id, AlarmStatus.READ);
         return new ResponseEntity(Header.OK(), HttpStatus.OK);
     }
+
 }

--- a/src/main/java/com/bootproj/pmcweb/Domain/Alarm.java
+++ b/src/main/java/com/bootproj/pmcweb/Domain/Alarm.java
@@ -1,0 +1,22 @@
+package com.bootproj.pmcweb.Domain;
+
+import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
+import com.bootproj.pmcweb.Domain.enumclass.AlarmType;
+import lombok.*;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class Alarm {
+    private Long id;
+    private AlarmType type;
+    private Date alarmTime;
+    private AlarmStatus status;
+    private Long userId;
+    private Long dateId;
+}

--- a/src/main/java/com/bootproj/pmcweb/Domain/enumclass/AlarmStatus.java
+++ b/src/main/java/com/bootproj/pmcweb/Domain/enumclass/AlarmStatus.java
@@ -1,0 +1,16 @@
+package com.bootproj.pmcweb.Domain.enumclass;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AlarmStatus {
+    NOT_READ(0, "NOT_READ", "아직 알람을 읽지 않은 상태"),
+    READ(1, "READ", "알람을 읽은 상태")
+    ;
+
+    private Integer id;
+    private String title;
+    private String description;
+}

--- a/src/main/java/com/bootproj/pmcweb/Domain/enumclass/AlarmType.java
+++ b/src/main/java/com/bootproj/pmcweb/Domain/enumclass/AlarmType.java
@@ -1,0 +1,16 @@
+package com.bootproj.pmcweb.Domain.enumclass;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AlarmType {
+    STUDY(0, "STUDY", "스터디 모임 일정 알람"),
+    MESSAGE(1, "MESSAGE", "메세지 알람")
+    ;
+
+    private int id;
+    private String title;
+    private String description;
+}

--- a/src/main/java/com/bootproj/pmcweb/Mapper/AlarmMapper.java
+++ b/src/main/java/com/bootproj/pmcweb/Mapper/AlarmMapper.java
@@ -1,5 +1,6 @@
 package com.bootproj.pmcweb.Mapper;
 
+import com.bootproj.pmcweb.Common.Response.AlarmApiResponse;
 import com.bootproj.pmcweb.Domain.Alarm;
 import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
 import lombok.AllArgsConstructor;
@@ -12,11 +13,11 @@ import java.util.Optional;
 
 @Repository
 public interface AlarmMapper {
-    public List<Alarm> getAlarmByUserId(Long userId);
+    public List<AlarmApiResponse> getAlarmByUserId(Long userId);
 
     public Optional<Alarm> getAlarmById (Long id);
 
-    public List<Alarm> getAlarmByUserIdStatus(@Param("userId") Long userId, @Param("status") AlarmStatus status);
+    public List<AlarmApiResponse> getAlarmByUserIdStatus(@Param("userId") Long userId, @Param("status") AlarmStatus status);
 
     public void createAlarm (Alarm alarm);
 

--- a/src/main/java/com/bootproj/pmcweb/Mapper/AlarmMapper.java
+++ b/src/main/java/com/bootproj/pmcweb/Mapper/AlarmMapper.java
@@ -1,7 +1,9 @@
 package com.bootproj.pmcweb.Mapper;
 
 import com.bootproj.pmcweb.Domain.Alarm;
+import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
 import lombok.AllArgsConstructor;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import java.sql.Date;
@@ -14,9 +16,11 @@ public interface AlarmMapper {
 
     public Optional<Alarm> getAlarmById (Long id);
 
+    public List<Alarm> getAlarmByUserIdStatus(@Param("userId") Long userId, @Param("status") AlarmStatus status);
+
     public void createAlarm (Alarm alarm);
 
-    public void updateAlarmStatus(Long id, String status);
+    public void updateAlarmStatus(@Param("id") Long id, @Param("status") AlarmStatus status);
 
     public void deleteAlarmById (Long id);
 

--- a/src/main/java/com/bootproj/pmcweb/Mapper/AlarmMapper.java
+++ b/src/main/java/com/bootproj/pmcweb/Mapper/AlarmMapper.java
@@ -1,0 +1,29 @@
+package com.bootproj.pmcweb.Mapper;
+
+import com.bootproj.pmcweb.Domain.Alarm;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AlarmMapper {
+    public List<Alarm> getAlarmByUserId(Long userId);
+
+    public Optional<Alarm> getAlarmById (Long id);
+
+    public void createAlarm (Alarm alarm);
+
+    public void updateAlarmStatus(Long id, String status);
+
+    public void deleteAlarmById (Long id);
+
+    public void deleteAlarmByUserId (Long userId);
+
+    public void deleteAlarmByDateId (Long dateId);
+
+    // 만약 스터디 호스트가 특정 스터디에 대한 알람을 어떤 유저가 읽었는지 확인하는 기능이 있다면 필요
+    // public List<Alarm> getAlarmByDateId (Long dateId);
+}

--- a/src/main/java/com/bootproj/pmcweb/Service/AlarmService.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AlarmService.java
@@ -1,5 +1,6 @@
 package com.bootproj.pmcweb.Service;
 
+import com.bootproj.pmcweb.Common.Response.AlarmApiResponse;
 import com.bootproj.pmcweb.Domain.Alarm;
 import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
 
@@ -7,7 +8,7 @@ import java.util.List;
 
 public interface AlarmService {
     public Alarm insert(Alarm alarm);
-    public List<Alarm> getNotReadListByUserId(Long userId);
-    public List<Alarm> getListByUserId(Long userId);
+    public List<AlarmApiResponse> getNotReadListByUserId(Long userId);
+    public List<AlarmApiResponse> getListByUserId(Long userId);
     public void updateStatusById(Long id, AlarmStatus status);
 }

--- a/src/main/java/com/bootproj/pmcweb/Service/AlarmService.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AlarmService.java
@@ -1,0 +1,12 @@
+package com.bootproj.pmcweb.Service;
+
+import com.bootproj.pmcweb.Domain.Alarm;
+import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
+
+import java.util.List;
+
+public interface AlarmService {
+    public Alarm insert(Alarm alarm);
+    public List<Alarm> getNotReadListByUserId(Long userId);
+    public void updateStatusById(Long id, AlarmStatus status);
+}

--- a/src/main/java/com/bootproj/pmcweb/Service/AlarmService.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AlarmService.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface AlarmService {
     public Alarm insert(Alarm alarm);
     public List<Alarm> getNotReadListByUserId(Long userId);
+    public List<Alarm> getListByUserId(Long userId);
     public void updateStatusById(Long id, AlarmStatus status);
 }

--- a/src/main/java/com/bootproj/pmcweb/Service/AlarmServiceImpl.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AlarmServiceImpl.java
@@ -32,6 +32,12 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
+    public List<Alarm> getListByUserId(Long userId) {
+        List<Alarm> alarms = alarmMapper.getAlarmByUserId(userId);
+        return alarms;
+    }
+
+    @Override
     public void updateStatusById(Long id, AlarmStatus status) {
         alarmMapper.updateAlarmStatus(id, status);
     }

--- a/src/main/java/com/bootproj/pmcweb/Service/AlarmServiceImpl.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AlarmServiceImpl.java
@@ -1,5 +1,6 @@
 package com.bootproj.pmcweb.Service;
 
+import com.bootproj.pmcweb.Common.Response.AlarmApiResponse;
 import com.bootproj.pmcweb.Domain.Alarm;
 import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
 import com.bootproj.pmcweb.Domain.enumclass.AlarmType;
@@ -26,14 +27,14 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
-    public List<Alarm> getNotReadListByUserId(Long userId) {
-        List<Alarm> alarms = alarmMapper.getAlarmByUserIdStatus(userId, AlarmStatus.NOT_READ);
+    public List<AlarmApiResponse> getNotReadListByUserId(Long userId) {
+        List<AlarmApiResponse> alarms = alarmMapper.getAlarmByUserIdStatus(userId, AlarmStatus.NOT_READ);
         return alarms;
     }
 
     @Override
-    public List<Alarm> getListByUserId(Long userId) {
-        List<Alarm> alarms = alarmMapper.getAlarmByUserId(userId);
+    public List<AlarmApiResponse> getListByUserId(Long userId) {
+        List<AlarmApiResponse> alarms = alarmMapper.getAlarmByUserId(userId);
         return alarms;
     }
 

--- a/src/main/java/com/bootproj/pmcweb/Service/AlarmServiceImpl.java
+++ b/src/main/java/com/bootproj/pmcweb/Service/AlarmServiceImpl.java
@@ -1,0 +1,38 @@
+package com.bootproj.pmcweb.Service;
+
+import com.bootproj.pmcweb.Domain.Alarm;
+import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
+import com.bootproj.pmcweb.Domain.enumclass.AlarmType;
+import com.bootproj.pmcweb.Mapper.AlarmMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class AlarmServiceImpl implements AlarmService {
+
+    @Autowired
+    AlarmMapper alarmMapper;
+
+    @Override
+    public Alarm insert(Alarm alarm) {
+        alarm.setType(AlarmType.STUDY);
+        alarm.setStatus(AlarmStatus.NOT_READ);
+        alarm.setAlarmTime(new Date(System.currentTimeMillis()));
+        alarmMapper.createAlarm(alarm);
+        return alarm;
+    }
+
+    @Override
+    public List<Alarm> getNotReadListByUserId(Long userId) {
+        List<Alarm> alarms = alarmMapper.getAlarmByUserIdStatus(userId, AlarmStatus.NOT_READ);
+        return alarms;
+    }
+
+    @Override
+    public void updateStatusById(Long id, AlarmStatus status) {
+        alarmMapper.updateAlarmStatus(id, status);
+    }
+}

--- a/src/main/resources/mappers/AlarmMapper.xml
+++ b/src/main/resources/mappers/AlarmMapper.xml
@@ -14,6 +14,11 @@
         where id = #{id};
     </select>
 
+    <select id="getAlarmByUserIdStatus" resultType="com.bootproj.pmcweb.Domain.Alarm">
+        select * from alarm
+        where user_id = #{userId} and status = #{status};
+    </select>
+
     <insert id="createAlarm" useGeneratedKeys="true" keyProperty="id">
         insert into alarm (type, alarm_time, status, user_id, date_id)
         values (#{type}, #{alarmTime}, #{status}, #{userId}, #{dateId});

--- a/src/main/resources/mappers/AlarmMapper.xml
+++ b/src/main/resources/mappers/AlarmMapper.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.bootproj.pmcweb.Mapper.AlarmMapper">
+
+    <select id="getAlarmByUserId" resultType="com.bootproj.pmcweb.Domain.Alarm">
+        select * from alarm
+        where user_id = #{userId};
+    </select>
+
+    <select id = "getAlarmById" resultType="com.bootproj.pmcweb.Domain.Alarm">
+        select * from alarm
+        where id = #{id};
+    </select>
+
+    <insert id="createAlarm" useGeneratedKeys="true" keyProperty="id">
+        insert into alarm (type, alarm_time, status, user_id, date_id)
+        values (#{type}, #{alarmTime}, #{status}, #{userId}, #{dateId});
+    </insert>
+
+    <update id="updateAlarmStatus">
+        update alarm set status = #{status}
+        where id = #{id};
+    </update>
+
+    <delete id="deleteAlarmById">
+        delete from alarm
+        where id = #{id};
+    </delete>
+
+    <delete id="deleteAlarmByUserId">
+        delete from alarm
+        where user_id = #{userId};
+    </delete>
+
+    <delete id="deleteAlarmByDateId">
+        delete from alarm
+        where date_id = #{dateId};
+    </delete>
+
+</mapper>

--- a/src/main/resources/mappers/AlarmMapper.xml
+++ b/src/main/resources/mappers/AlarmMapper.xml
@@ -4,9 +4,10 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.bootproj.pmcweb.Mapper.AlarmMapper">
 
-    <select id="getAlarmByUserId" resultType="com.bootproj.pmcweb.Domain.Alarm">
-        select * from alarm
-        where user_id = #{userId};
+    <select id="getAlarmByUserId" resultType="com.bootproj.pmcweb.Common.Response.AlarmApiResponse">
+        SELECT alarm.*, date.description
+        FROM alarm join date
+        on alarm.date_id = date.id and user_id = #{userId};
     </select>
 
     <select id = "getAlarmById" resultType="com.bootproj.pmcweb.Domain.Alarm">
@@ -14,9 +15,10 @@
         where id = #{id};
     </select>
 
-    <select id="getAlarmByUserIdStatus" resultType="com.bootproj.pmcweb.Domain.Alarm">
-        select * from alarm
-        where user_id = #{userId} and status = #{status};
+    <select id="getAlarmByUserIdStatus" resultType="com.bootproj.pmcweb.Common.Response.AlarmApiResponse">
+        SELECT alarm.*, date.description
+        FROM alarm join date
+        on alarm.date_id = date.id and user_id = #{userId} and status = #{status};
     </select>
 
     <insert id="createAlarm" useGeneratedKeys="true" keyProperty="id">

--- a/src/main/resources/templates/layout/alarm.html
+++ b/src/main/resources/templates/layout/alarm.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lagn="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+    <th:block th:fragment="fragment-alarm">
+        <a class="nav-link dropdown-toggle" href="#" id="alertsDropdown" role="button"
+           data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" th:onclick="alarmButton()">
+            <i class="fas fa-bell fa-fw"></i>
+            <!-- Counter - Alerts -->
+            <span class="badge badge-danger badge-counter">3+</span>
+        </a>
+
+        <!-- Dropdown - Alerts -->
+        <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in"
+             aria-labelledby="alertsDropdown" id="alertDropdownList">
+            <h6 class="dropdown-header">
+                알람 리스트
+            </h6>
+            <a class="dropdown-item d-flex align-items-center" href="#" id="alertNotRead">
+                <div class="mr-3">
+                    <div class="icon-circle">
+                        <i class="far fa-calendar-alt" style="color:#178828;"></i>
+                    </div>
+                </div>
+                <div>
+                    <div class="small text-gray-500">December 12, 2019</div>
+                    <span class="font-weight-bold">A new monthly report is ready to download!</span>
+                </div>
+            </a>
+            <a class="dropdown-item d-flex align-items-center" href="#" id="alertRead">
+                <div class="mr-3">
+                    <div class="icon-circle">
+                        <i class="far fa-calendar-alt" style="color:#939393;"></i>
+                    </div>
+                </div>
+                <div>
+                    <div class="small text-gray-500">December 7, 2019</div>
+                    $290.29 has been deposited into your account!
+                </div>
+            </a>
+            <a class="dropdown-item text-center small text-gray-500" href="#">Show All Alerts</a>
+        </div>
+        <th:block th:replace="/layout/alarmScript.html :: fragment-alarm-script"/>
+    </th:block>
+</html>

--- a/src/main/resources/templates/layout/alarmScript.html
+++ b/src/main/resources/templates/layout/alarmScript.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lagn="ko" xmlns:th="http://www.thymeleaf.org">
+    <th:block th:fragment="fragment-alarm-script">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
+        <script th:inline="javascript">
+            const htmlStart = "<h6 class=\"dropdown-header\">\n" +
+                "                알람 리스트\n" +
+                "            </h6>";
+            const notReadHtml1 = "<a class=\"dropdown-item d-flex align-items-center\" href=\"#\" id=\"alertNotRead\">\n" +
+                "                <div class=\"mr-3\">\n" +
+                "                    <div class=\"icon-circle\">\n" +
+                "                        <i class=\"far fa-calendar-alt\" style=\"color:#178828;\"></i>\n" +
+                "                    </div>\n" +
+                "                </div>\n" +
+                "                <div>\n" +
+                "                    <div class=\"small text-gray-500\">";
+            const notReadHtml2 = "</div>\n" +
+                "                    <span class=\"font-weight-bold\">";
+            const notReadHtml3 = "</span>\n" +
+                "                </div>\n" +
+                "            </a>";
+            const readHtml1 = "<a class=\"dropdown-item d-flex align-items-center\" href=\"#\" id=\"alertRead\">\n" +
+                "                <div class=\"mr-3\">\n" +
+                "                    <div class=\"icon-circle\">\n" +
+                "                        <i class=\"far fa-calendar-alt\" style=\"color:#939393;\"></i>\n" +
+                "                    </div>\n" +
+                "                </div>\n" +
+                "                <div>\n" +
+                "                    <div class=\"small text-gray-500\">";
+            const readHtml2 = "</div>";
+            const readHtml3 = "</div>\n" +
+                "            </a>";
+            const htmlEnd = "<a class=\"dropdown-item text-center small text-gray-500\" href=\"#\">Show All Alerts</a>";
+            /*<![CDATA[*/
+            let alarm = "";
+            const dateFormat = "YYYY-MM-DD HH:mm:ss";
+            console.log("navbar alarm script")
+
+            function alarmButton(){
+                /*<![CDATA[*/
+                let url = "http://localhost:8080/alarm";
+                /*]]>*/
+                if (this.value !== "") {
+                    fetch(url, {
+                        method: 'GET',
+                    }).then(function (response) {
+                        return response.json();
+                    }).then(function (data) {
+                        /*<![CDATA[*/
+                        let alarms = data.data;
+                        console.log(alarms);
+                        let html = htmlStart;
+                        for(let i=0; i<alarms.length; i++){
+                            if (alarms[i].status == "NOT_READ"){
+                                html += notReadHtml1 + moment(new Date(alarms[i].alarm_time)).format("YYYY-MM-DD HH:mm:ss") + notReadHtml2 + alarms[i].description + notReadHtml3;
+                            } else if (alarms[i].status == "READ"){
+                                html += readHtml1 + moment(new Date(alarms[i].alarm_time)).format("YYYY-MM-DD HH:mm:ss") + readHtml2 + alarms[i].description + readHtml3;
+                            }
+                        }
+                        html += htmlEnd;
+                        document.getElementById("alertDropdownList").innerHTML= html;
+                    }).catch(error => alert(error));
+                }
+            };
+        </script>
+    </th:block>
+</html>

--- a/src/main/resources/templates/layout/commonScript.html
+++ b/src/main/resources/templates/layout/commonScript.html
@@ -6,6 +6,5 @@
     <!-- Bootstrap core JavaScript-->
     <script th:src="@{/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
     <script th:src="@{/vendor/jquery/jquery.min.js}"></script>
-
 </th:block>
 </html>

--- a/src/main/resources/templates/layout/navbar.html
+++ b/src/main/resources/templates/layout/navbar.html
@@ -15,6 +15,7 @@
                 </span>
                 <div class="collapse navbar-collapse" id="navbarResponsive">
                     <ul class="navbar-nav ml-auto">
+
                         <li class="nav-item">
                             <a class="nav-link" sec:authorize="isAnonymous()" th:href="@{/user/login}">로그인</a>
                         </li>
@@ -47,6 +48,57 @@
                         </li>
                         <li class="nav-item">
                             <a sec:authorize="isAuthenticated()" class="nav-link" href="#" th:href="@{/study/register}"><i class="fas fa-plus"></i></a>
+                        </li>
+
+                        <!-- Nav Item - Alerts -->
+                        <li class="nav-item dropdown no-arrow mx-1">
+                            <a sec:authorize="isAuthenticated()" class="nav-link dropdown-toggle" href="#" id="alertsDropdown" role="button"
+                               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <i class="fas fa-bell fa-fw"></i>
+                                <!-- Counter - Alerts -->
+                                <span class="badge badge-danger badge-counter">3+</span>
+                            </a>
+                            <!-- Dropdown - Alerts -->
+                            <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in"
+                                 aria-labelledby="alertsDropdown">
+                                <h6 class="dropdown-header">
+                                    알람 리스트
+                                </h6>
+                                <a class="dropdown-item d-flex align-items-center" href="#">
+                                    <div class="mr-3">
+                                        <div class="icon-circle bg-primary">
+                                            <i class="fas fa-file-alt text-white"></i>
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <div class="small text-gray-500">December 12, 2019</div>
+                                        <span class="font-weight-bold">A new monthly report is ready to download!</span>
+                                    </div>
+                                </a>
+                                <a class="dropdown-item d-flex align-items-center" href="#">
+                                    <div class="mr-3">
+                                        <div class="icon-circle bg-success">
+                                            <i class="fas fa-donate text-white"></i>
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <div class="small text-gray-500">December 7, 2019</div>
+                                        $290.29 has been deposited into your account!
+                                    </div>
+                                </a>
+                                <a class="dropdown-item d-flex align-items-center" href="#">
+                                    <div class="mr-3">
+                                        <div class="icon-circle bg-warning">
+                                            <i class="fas fa-exclamation-triangle text-white"></i>
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <div class="small text-gray-500">December 2, 2019</div>
+                                        Spending Alert: We've noticed unusually high spending for your account.
+                                    </div>
+                                </a>
+                                <a class="dropdown-item text-center small text-gray-500" href="#">Show All Alerts</a>
+                            </div>
                         </li>
                     </ul>
                 </div>

--- a/src/main/resources/templates/layout/navbar.html
+++ b/src/main/resources/templates/layout/navbar.html
@@ -51,54 +51,8 @@
                         </li>
 
                         <!-- Nav Item - Alerts -->
-                        <li class="nav-item dropdown no-arrow mx-1">
-                            <a sec:authorize="isAuthenticated()" class="nav-link dropdown-toggle" href="#" id="alertsDropdown" role="button"
-                               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                <i class="fas fa-bell fa-fw"></i>
-                                <!-- Counter - Alerts -->
-                                <span class="badge badge-danger badge-counter">3+</span>
-                            </a>
-                            <!-- Dropdown - Alerts -->
-                            <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in"
-                                 aria-labelledby="alertsDropdown">
-                                <h6 class="dropdown-header">
-                                    알람 리스트
-                                </h6>
-                                <a class="dropdown-item d-flex align-items-center" href="#">
-                                    <div class="mr-3">
-                                        <div class="icon-circle bg-primary">
-                                            <i class="fas fa-file-alt text-white"></i>
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <div class="small text-gray-500">December 12, 2019</div>
-                                        <span class="font-weight-bold">A new monthly report is ready to download!</span>
-                                    </div>
-                                </a>
-                                <a class="dropdown-item d-flex align-items-center" href="#">
-                                    <div class="mr-3">
-                                        <div class="icon-circle bg-success">
-                                            <i class="fas fa-donate text-white"></i>
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <div class="small text-gray-500">December 7, 2019</div>
-                                        $290.29 has been deposited into your account!
-                                    </div>
-                                </a>
-                                <a class="dropdown-item d-flex align-items-center" href="#">
-                                    <div class="mr-3">
-                                        <div class="icon-circle bg-warning">
-                                            <i class="fas fa-exclamation-triangle text-white"></i>
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <div class="small text-gray-500">December 2, 2019</div>
-                                        Spending Alert: We've noticed unusually high spending for your account.
-                                    </div>
-                                </a>
-                                <a class="dropdown-item text-center small text-gray-500" href="#">Show All Alerts</a>
-                            </div>
+                        <li sec:authorize="isAuthenticated()" class="nav-item dropdown no-arrow mx-1">
+                            <th:block th:replace="/layout/alarm.html :: fragment-alarm"/>
                         </li>
                     </ul>
                 </div>

--- a/src/test/java/com/bootproj/pmcweb/Mapper/AlarmMapperTest.java
+++ b/src/test/java/com/bootproj/pmcweb/Mapper/AlarmMapperTest.java
@@ -1,0 +1,118 @@
+package com.bootproj.pmcweb.Mapper;
+
+import com.bootproj.pmcweb.Domain.Alarm;
+import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
+import com.bootproj.pmcweb.Domain.enumclass.AlarmType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.sql.Date;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Log4j2
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class AlarmMapperTest {
+    private final String dateFormat = "yyyy-MM-dd HH:mm:ss";
+    private long testUserId = 99L;
+    private long testDateId = 1L;
+    private long testId = 2L;
+
+    @Autowired
+    AlarmMapper alarmMapper;
+
+    @Test
+    void getAlarmByUserId() {
+        List<Alarm> alarms = alarmMapper.getAlarmByUserId(testUserId);
+        log.info(alarms);
+        Assert.assertTrue(alarms.size()>0);
+    }
+
+    @Test
+    void getAlarmById() {
+        Optional<Alarm> optionalAlarm = alarmMapper.getAlarmById(testId);
+        log.info(optionalAlarm.orElse(null));
+        Assert.assertTrue(optionalAlarm.isPresent());
+    }
+
+    @Test
+    void createAlarm() {
+        Alarm alarm = Alarm.builder()
+                .type(AlarmType.STUDY)
+                .status(AlarmStatus.NOT_READ)
+                .alarmTime(new Date(System.currentTimeMillis()))
+                .userId(testUserId)
+                .dateId(testDateId)
+                .build();
+
+        alarmMapper.createAlarm(alarm);
+        log.info(alarm);
+        Assert.assertNotNull(alarm.getId());
+    }
+
+    @Test
+    void updateAlarmStatus() {
+        alarmMapper.getAlarmById(testId).ifPresentOrElse(
+                (alarm) -> {
+                    Assert.assertEquals(AlarmStatus.NOT_READ.getTitle(), alarm.getStatus());
+                },
+                () -> {
+                    createAlarmBeforeTest();
+                }
+        );
+        alarmMapper.updateAlarmStatus(testId, AlarmStatus.READ.getTitle());
+        Assert.assertEquals(alarmMapper.getAlarmById(testId).get().getStatus(), AlarmStatus.READ.getTitle());
+    }
+
+    @Test
+    void deleteAlarmById() {
+        alarmMapper.getAlarmById(testId).ifPresentOrElse(
+                (alarm) -> {
+                    assertEquals(testId, alarm.getId());
+                },
+                () -> {
+                    testId = createAlarmBeforeTest();
+                }
+        );
+        alarmMapper.deleteAlarmById(testId);
+        assertTrue(alarmMapper.getAlarmById(testId).isEmpty());
+    }
+
+    @Test
+    void deleteAlarmByUserId() {
+        List<Alarm> alarms = alarmMapper.getAlarmByUserId(testUserId);
+        assertTrue(alarms.size()>0);
+        alarmMapper.deleteAlarmByUserId(testUserId);
+        assertTrue(alarmMapper.getAlarmById(testId).isEmpty());
+    }
+
+    @Test
+    void deleteAlarmByDateId() {
+        alarmMapper.deleteAlarmByDateId(testDateId);
+        assertTrue(alarmMapper.getAlarmById(testId).isEmpty());
+    }
+
+    private Long createAlarmBeforeTest(){
+        Alarm alarm = Alarm.builder()
+                .type(AlarmType.STUDY)
+                .status(AlarmStatus.NOT_READ)
+                .alarmTime(new Date(System.currentTimeMillis()))
+                .userId(testUserId)
+                .dateId(testDateId)
+                .build();
+
+        alarmMapper.createAlarm(alarm);
+        return alarm.getId();
+    }
+}

--- a/src/test/java/com/bootproj/pmcweb/Mapper/AlarmMapperTest.java
+++ b/src/test/java/com/bootproj/pmcweb/Mapper/AlarmMapperTest.java
@@ -1,5 +1,6 @@
 package com.bootproj.pmcweb.Mapper;
 
+import com.bootproj.pmcweb.Common.Response.AlarmApiResponse;
 import com.bootproj.pmcweb.Domain.Alarm;
 import com.bootproj.pmcweb.Domain.enumclass.AlarmStatus;
 import com.bootproj.pmcweb.Domain.enumclass.AlarmType;
@@ -24,8 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 class AlarmMapperTest {
-    private final String dateFormat = "yyyy-MM-dd HH:mm:ss";
-    private long testUserId = 99L;
+    private long testUserId = 50L;
     private long testDateId = 1L;
     private long testId = 3L;
 
@@ -34,7 +34,7 @@ class AlarmMapperTest {
 
     @Test
     void getAlarmByUserId() {
-        List<Alarm> alarms = alarmMapper.getAlarmByUserId(testUserId);
+        List<AlarmApiResponse> alarms = alarmMapper.getAlarmByUserId(testUserId);
         log.info(alarms);
         Assert.assertTrue(alarms.size()>0);
     }
@@ -75,7 +75,7 @@ class AlarmMapperTest {
 
     @Test
     void deleteAlarmByUserId() {
-        List<Alarm> alarms = alarmMapper.getAlarmByUserId(testUserId);
+        List<AlarmApiResponse> alarms = alarmMapper.getAlarmByUserId(testUserId);
         assertTrue(alarms.size()>0);
         alarmMapper.deleteAlarmByUserId(testUserId);
         assertTrue(alarmMapper.getAlarmById(testId).isEmpty());
@@ -102,7 +102,7 @@ class AlarmMapperTest {
 
     @Test
     void getAlarmByUserIdStatus() {
-        List<Alarm> alarms = alarmMapper.getAlarmByUserIdStatus(testUserId, AlarmStatus.NOT_READ);
+        List<AlarmApiResponse> alarms = alarmMapper.getAlarmByUserIdStatus(testUserId, AlarmStatus.NOT_READ);
         log.info(alarms);
         Assert.assertTrue(alarms.size()>0);
     }

--- a/src/test/java/com/bootproj/pmcweb/Mapper/AlarmMapperTest.java
+++ b/src/test/java/com/bootproj/pmcweb/Mapper/AlarmMapperTest.java
@@ -27,7 +27,7 @@ class AlarmMapperTest {
     private final String dateFormat = "yyyy-MM-dd HH:mm:ss";
     private long testUserId = 99L;
     private long testDateId = 1L;
-    private long testId = 2L;
+    private long testId = 3L;
 
     @Autowired
     AlarmMapper alarmMapper;
@@ -63,28 +63,12 @@ class AlarmMapperTest {
 
     @Test
     void updateAlarmStatus() {
-        alarmMapper.getAlarmById(testId).ifPresentOrElse(
-                (alarm) -> {
-                    Assert.assertEquals(AlarmStatus.NOT_READ.getTitle(), alarm.getStatus());
-                },
-                () -> {
-                    createAlarmBeforeTest();
-                }
-        );
-        alarmMapper.updateAlarmStatus(testId, AlarmStatus.READ.getTitle());
-        Assert.assertEquals(alarmMapper.getAlarmById(testId).get().getStatus(), AlarmStatus.READ.getTitle());
+        alarmMapper.updateAlarmStatus(testId, AlarmStatus.READ);
+        Assert.assertEquals(alarmMapper.getAlarmById(testId).get().getStatus(), AlarmStatus.READ);
     }
 
     @Test
     void deleteAlarmById() {
-        alarmMapper.getAlarmById(testId).ifPresentOrElse(
-                (alarm) -> {
-                    assertEquals(testId, alarm.getId());
-                },
-                () -> {
-                    testId = createAlarmBeforeTest();
-                }
-        );
         alarmMapper.deleteAlarmById(testId);
         assertTrue(alarmMapper.getAlarmById(testId).isEmpty());
     }
@@ -114,5 +98,12 @@ class AlarmMapperTest {
 
         alarmMapper.createAlarm(alarm);
         return alarm.getId();
+    }
+
+    @Test
+    void getAlarmByUserIdStatus() {
+        List<Alarm> alarms = alarmMapper.getAlarmByUserIdStatus(testUserId, AlarmStatus.NOT_READ);
+        log.info(alarms);
+        Assert.assertTrue(alarms.size()>0);
     }
 }


### PR DESCRIPTION
[alarm][feat] alarm domain, mapper, mapper test code 추가

[alarm][feat] alarm service, controller 추가
- 유저의 읽지 않은 알림 목록을 가져오는 서비스
- 유저의 알림을 읽은 상태로 변경하는 서비스

[alarm][fix] alarm service 변경 (유저의 전체 알람리스트를 받아오도록 변경) 
- 읽지 않은 리스트가 아닌 전체 리스트를 가져오도록 변경
- 프론트에서 전체 리스트에서 읽은 것도 보여주되, 읽지 않은 것을 볼드처리할 예정

[alarm][feat] navbar에 알람 화면 추가
- alarm.html, alarmScript.html 추가, navbar에 th:block으로 추가

[alarm][feat] 알람 기능 연동
- alarm 에서 date 테이블의 description도 보여주도록 조인하는 테이블로 변경
- AlarmApiResponse에 description 추가
- alarm.html에서 알람 화면 세부사항 변경
- alarmScript에서 서비스콜 한 데이터를 가져와서 화면에 보여주도록 추가
    - status가 READ인 것은 bord처리, green으로 보이도록 하고, NOT_READ상태인 것은 회색 글씨로 나오도록 추가 완료
- dateFormat을 일정하게 보여줄 수 있도록 commonUtil에 추가